### PR TITLE
pkg: tweak for prod deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ You'll first want to `cp .env.example .env` and configure your LLM.
 
 Then, to get started hacking, just run `npm run dev`. To run this repo in production, you can run `npm run build && npm run start`.
 
+In development, your app is available at `http://localhost:5173`, talking to the server at `http://localhost:3040`. By default, in production your app is available at `http://localhost`.
+
 ### `agent`
 
 This folder includes the configuration for your agent, which is powered by your LLM. Your LLM has its own system and agent prompt. Both are configurable here.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently \"npm run app-dev\" \"npm run server\"",
     "postinstall": "cd app && npm install",
     "server": "npx tsx ./server/index.ts",
-    "start": "node ./dist/index.js"
+    "start": "NODE_ENV=production npm run server"
   },
   "author": "",
   "license": "MIT",

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import { CustomSchema } from "../extensions/schema";
 import "dotenv/config";
 
 const app = express();
-const port = 3040;
+const port = process.env.NODE_ENV === "production" ? 80 : 3040;
 
 app.listen(port, () => {
   console.log(`Server started on http://localhost:${port}`);


### PR DESCRIPTION
Fixes #6.

Very small changes. Just changes the `npm run start` command to only run the back-end server, since the server already has logic for mounting the built front-end in prod. Now on prod we mount at port 80.